### PR TITLE
feat(commits): adicionar estatísticas dos últimos 30 commits.

### DIFF
--- a/src/github-crescer.js
+++ b/src/github-crescer.js
@@ -95,6 +95,33 @@ module.exports = (function() {
       callBack);
   };
 
+  function buildCommitStats(commits) {
+    var feat_count = 0, fix_count = 0, refactor_count = 0, merge_count = 0, test_count = 0;
+        
+    commits.forEach(function(c) {
+      if (c.commit.message.toLowerCase().indexOf('feat') > -1) {
+        feat_count++;
+      } else if (c.commit.message.toLowerCase().indexOf('fix') > -1) {
+        fix_count++;
+      } else if (c.commit.message.toLowerCase().indexOf('refactor') > -1) {
+        refactor_count++;
+      } else if (c.commit.message.toLowerCase().indexOf('merge') > -1) {
+        merge_count++;
+      } else if (c.commit.message.toLowerCase().indexOf('test') > -1) {
+        test_count++;
+      }
+    });
+
+    return {
+      all: commits.length,
+      features: feat_count,
+      fixes: fix_count,
+      refactor: refactor_count,
+      merge: merge_count,
+      test: test_count
+    };
+  };
+
   function buildActivity(fork, commits) {
     var timestamp = date.difference(new Date(fork.pushed_at), new Date());
 
@@ -105,6 +132,7 @@ module.exports = (function() {
       warning: timestamp.inDays > 0,
       pushed_date: new Date(fork.pushed_at),
       pushed_timestamp: timestamp,
+      commits_stats: buildCommitStats(commits),
       last_commits: [
         {
           message: commits[0].commit.message,

--- a/src/github-crescer.js
+++ b/src/github-crescer.js
@@ -96,30 +96,25 @@ module.exports = (function() {
   };
 
   function buildCommitStats(commits) {
-    var feat_count = 0, fix_count = 0, refactor_count = 0, merge_count = 0, test_count = 0;
-        
+    var stats = {
+      feat: 0,
+      fix: 0,
+      refactor: 0,
+      merge: 0,
+      test: 0
+    };
+
     commits.forEach(function(c) {
-      if (c.commit.message.toLowerCase().indexOf('feat') > -1) {
-        feat_count++;
-      } else if (c.commit.message.toLowerCase().indexOf('fix') > -1) {
-        fix_count++;
-      } else if (c.commit.message.toLowerCase().indexOf('refactor') > -1) {
-        refactor_count++;
-      } else if (c.commit.message.toLowerCase().indexOf('merge') > -1) {
-        merge_count++;
-      } else if (c.commit.message.toLowerCase().indexOf('test') > -1) {
-        test_count++;
+      for (var prop in stats) {
+        if (c.commit.message.toLowerCase().indexOf(prop) > -1) {
+          stats[prop]++;
+        }
       }
     });
 
-    return {
-      all: commits.length,
-      features: feat_count,
-      fixes: fix_count,
-      refactor: refactor_count,
-      merge: merge_count,
-      test: test_count
-    };
+    stats.all = commits.length;
+
+    return stats;
   };
 
   function buildActivity(fork, commits) {

--- a/src/web/views/home.html
+++ b/src/web/views/home.html
@@ -71,21 +71,33 @@
               </div>
               <table id="tabela-commits" class="table table-striped table-hover table-condensed">
                 <thead>
-                  <th></th>
                   <th>Usuário</th>
-                  <th class="col-md-2 col-sm-3">Última aparição</th>
+                  <th>Última aparição</th>
+                  <th>Estatísticas</th>
                   <th class="col-md-8 col-sm-7">Commits</th>
                 </thead>
                 <tbody>
                   <tr ng-repeat="rep in repositories" ng-class="{ 'danger': rep.warning }" class="animated bounceIn" >
                     <td>
-                      <img ng-src="{{ rep.avatar_url }}" class="avatar">
-                    </td>
-                    <td>
-                      <a target='_blank' href='{{ rep.url_fork }}'>{{ rep.user }}</a>
+                      <a target='_blank' href='{{ rep.url_fork }}'>
+                        <img ng-src="{{ rep.avatar_url }}" class="avatar"><br>
+                        {{ rep.user }}
+                      </a>
                     </td>
                     <td>
                       {{ rep.pushed_timestamp | timestamp }}
+                    </td>
+                    <td>
+                      <span class="commits-anteriores">
+                        Últimos 30 commits
+                        <ul>
+                          <li>Feature: {{ rep.commits_stats.features }}</li>
+                          <li>Fix: {{ rep.commits_stats.fixes }}</li>
+                          <li>Refactory: {{ rep.commits_stats.refactor }}</li>
+                          <li>Merge: {{ rep.commits_stats.merge }}</li>
+                          <li>Test: {{ rep.commits_stats.test }}</li>
+                        </ul>
+                      </span>
                     </td>
                     <td>
                       Último Commit: <a target='_blank' href='{{ rep.last_commits[0].url }}'>{{ rep.last_commits[0].message }}</a>

--- a/src/web/views/home.html
+++ b/src/web/views/home.html
@@ -91,8 +91,8 @@
                       <span class="commits-anteriores">
                         Últimos 30 commits
                         <ul>
-                          <li>Feature: {{ rep.commits_stats.features }}</li>
-                          <li>Fix: {{ rep.commits_stats.fixes }}</li>
+                          <li>Feature: {{ rep.commits_stats.feat }}</li>
+                          <li>Fix: {{ rep.commits_stats.fix }}</li>
                           <li>Refactory: {{ rep.commits_stats.refactor }}</li>
                           <li>Merge: {{ rep.commits_stats.merge }}</li>
                           <li>Test: {{ rep.commits_stats.test }}</li>


### PR DESCRIPTION
Versão expressa para atender parcialmente o item #18 

Preview (coluna estatísticas):
![image](https://cloud.githubusercontent.com/assets/526075/14416252/2dd618ba-ff7e-11e5-8da5-90a804d46016.png)

Pendências:
- [ ] Criar página com gráfico (sugestão: pie chart) de commits por atividade
- [ ] Criar gráfico barras com commits por fork
